### PR TITLE
Fixes the module to work on CentOS

### DIFF
--- a/diskspace.js
+++ b/diskspace.js
@@ -52,9 +52,9 @@
 					}
 					else
 					{
-						var lines = stdout.split("\n");
+						var lines = stdout.trim().split("\n");
 						
-						var str_disk_info = lines[1].replace( /[\s\n\r]+/g,' ');
+						var str_disk_info = lines[lines.length - 1].replace( /[\s\n\r]+/g,' ');
 						var disk_info = str_disk_info.split(' ');
 						
 						total = disk_info[1] * 1024;


### PR DESCRIPTION
This module uses the df -k command to get the disk usage info. Problem is that the output for df -k is slightly different on CentOS than on other linux distributions.

On CentOS, for example, "df -k /" can output this:

Filesystem 1K-blocks Used Available Use% Mounted on
/dev/mapper/VolGroup-lv_root
51606140 5131448 43853252 11% /

Notice there are 3 lines in the output above. On debian squeeze and other linux distributions the output is only two lines, like this:

Filesystem 1K-blocks Used Available Use% Mounted on
/dev/sda1 7867856 1768364 5699828 24% /

The problem is that the code always looks for the data on the second line of output. The safer thing to do is to look at the last line of output.

My change fixes this.
