### PR TITLE
bugfix: Checking a drive that doesn't exist would produce wrong results.

### DIFF
--- a/diskspace.js
+++ b/diskspace.js
@@ -26,18 +26,22 @@ function check(drive, callback)
 			if (error)
 			{
 				status = 'STDERR';
-				callback ? callback(error, total, free, status)
-						 : console.error(stderr);
 			}
 			else
 			{
-				var disk_info = stdout.split(',');
+				var disk_info = stdout.trim().split(',');
 
 				total = disk_info[0];
 				free = disk_info[1];
 				status = disk_info[2];
 
-				callback && callback(null, total, free, status);
+				if (status == 'NOTFOUND')
+				{
+					error = new Error('Drive not found');
+				}
+
+				callback ? callback(error, total, free, status)
+						 : console.error(stderr);
 			}
 		});
 	}

--- a/test.js
+++ b/test.js
@@ -17,6 +17,7 @@ else
 
 diskspace.check(drive_letter, function (err, total, free, status)
 {
+    console.log('err: ' + err);
 	console.log('Total: ' + total);
 	console.log('Free: ' + free);
 	console.log('Status: ' + status);


### PR DESCRIPTION
Here is how the story goes: When I write a simple demo snippet

```
function DoTest() {
    diskspace.check('E', function(err, total, free, status) {
        console.log(err);
        console.log(status);
    });
}
```

where the drive `E` is not present in my computer (running Windows 7). 

I ran the code and found the value of `err` is `null` and `status` is `undefined`. That's definitely not accordable with description in the document.

Thus I checked inside of source and fixed the bug, at least in my point of view.

BTW, the bugfix commit of the underlying program `diskspace` can be found on https://github.com/keverw/drivespace/pull/1.

